### PR TITLE
fix: Github credentials not required anymore for build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,12 +23,6 @@ project(jitify LANGUAGES CXX HIP)
 # Set the path to libhipcxx GitHub repository inside the build directory
 set(LIBHIPCXX_DIR ${CMAKE_BINARY_DIR}/libhipcxx)
 
-# Print error if GITHUB_USER or GITHUB_PASS are not set
-if(NOT DEFINED ENV{GITHUB_USER})
-  message(FATAL_ERROR "ERROR: GITHUB_USER or GITHUB_PASS are not set. Libhipcxx is not cloned!")
-endif()
-
-# Todo(HIP): Remove "--branch hiprtc" once hiprtc branch in libhipcxx is merged with the main branch 
 # Download libhipcxx repository using Git
 find_package(Git REQUIRED)
 execute_process(

--- a/scripts/build_and_run_tests.sh
+++ b/scripts/build_and_run_tests.sh
@@ -40,19 +40,6 @@ export JITIFY_ROOT="$(cd "$(dirname "$0")" && cd ../ && pwd)"
 echo "Check environment"
 env
 
-echo "Check that Github access token is set up"
-if [ -z ${GITHUB_PASS} ]
-then 
-  echo "Error: You need to set GITHUB_PASS (personal access token) to install jitify dependencies via rapids-cmake from github"	
-  exit -1
-fi
-
-if [ -z ${GITHUB_USER} ]
-then 
-  echo "Error: You need to set GITHUB_USER (personal access token) to install jitify dependencies via rapids-cmake from github"	
-  exit -1
-fi
-
 echo "Check GPU usage"
 rocm-smi
 
@@ -69,4 +56,3 @@ mkdir -p build
 cd build
 cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=hipcc ..
 make
-


### PR DESCRIPTION
Dependency `libhipcxx` is released now and the script is already specifies the public repository in the download URL.

# TODO

* [x] Check that it builds via CI.